### PR TITLE
Mainly fix the problem with the Settings File.

### DIFF
--- a/Editor/EditorGitTool.cs
+++ b/Editor/EditorGitTool.cs
@@ -78,6 +78,9 @@ namespace kamgam.editor.GitTool
 
             AssetDatabase.DeleteAsset(gitHashFilePath);
             var text = new TextAsset(gitHash + postFix);
+            // Check if a folder needs to be created
+            if (!AssetDatabase.IsValidFolder("Assets/Resources"))
+                AssetDatabase.CreateFolder("Assets", "Resources");
             AssetDatabase.CreateAsset(text, gitHashFilePath);
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();

--- a/Editor/EditorGitTool.cs
+++ b/Editor/EditorGitTool.cs
@@ -203,7 +203,8 @@ namespace kamgam.editor.GitTool
                 );
                 if (continueWithoutCommit == false)
                 {
-                    throw new Exception("User canceled build because there are still uncommitted changes.");
+                    // In Unity 2018.4+ throwing a normal "Exception" in OnPreprocessBuild() will no longer stop the build, but throwing a "BuildFailedException" will. 
+                    throw new BuildFailedException("User canceled build because there are still uncommitted changes.");
                 }
             }
 

--- a/Editor/EditorGitTool.cs
+++ b/Editor/EditorGitTool.cs
@@ -59,7 +59,7 @@ namespace kamgam.editor.GitTool
             if(string.IsNullOrEmpty(gitHashFilePath))
             {
 #if UNITY_2018_4_OR_NEWER
-                gitHashFilePath = GitToolSettings.GetOrCreateSettings().GitHashTextAssetPath;
+                gitHashFilePath = EditorGitToolSettings.GetOrCreateSettings().GitHashTextAssetPath;
 #else
                 gitHashFilePath = GitHashFilePath;
 #endif
@@ -184,7 +184,7 @@ namespace kamgam.editor.GitTool
         {
             // show warning
 #if UNITY_2018_4_OR_NEWER
-            bool showWarning = GitToolSettings.GetOrCreateSettings().ShowWarning;
+            bool showWarning = EditorGitToolSettings.GetOrCreateSettings().ShowWarning;
 #else
             bool showWarning = EditorGitTool.ShowWarning;
 #endif

--- a/Editor/EditorGitToolSettings.cs
+++ b/Editor/EditorGitToolSettings.cs
@@ -32,6 +32,9 @@ namespace kamgam.editor.GitTool
                 settings = ScriptableObject.CreateInstance<EditorGitToolSettings>();
                 settings.GitHashTextAssetPath = EditorGitTool.DefaultGitHashFilePath;
                 settings.ShowWarning = true;
+                // Check if a folder needs to be created
+                if (!AssetDatabase.IsValidFolder("Assets/Editor"))
+                    AssetDatabase.CreateFolder("Assets", "Editor");
                 AssetDatabase.CreateAsset(settings, SettingsFilePath);
                 AssetDatabase.SaveAssets();
             }

--- a/Editor/EditorGitToolSettings.cs
+++ b/Editor/EditorGitToolSettings.cs
@@ -9,9 +9,9 @@ namespace kamgam.editor.GitTool
 {
 #if UNITY_2018_4_OR_NEWER
     // Create a new type of Settings Asset.
-    class GitToolSettings : ScriptableObject
+    class EditorGitToolSettings : ScriptableObject
     {
-        public const string SettingsFilePath = "Assets/Editor/GitToolSettings.asset";
+        public const string SettingsFilePath = "Assets/Editor/EditorGitToolSettings.asset";
 
         [SerializeField]
         public string GitHashTextAssetPath;
@@ -19,12 +19,17 @@ namespace kamgam.editor.GitTool
         [SerializeField]
         public bool ShowWarning;
 
-        internal static GitToolSettings GetOrCreateSettings()
+        private static EditorGitToolSettings settings = null;
+
+        internal static EditorGitToolSettings GetOrCreateSettings()
         {
-            var settings = AssetDatabase.LoadAssetAtPath<GitToolSettings>(SettingsFilePath);
+            if (settings != null)
+                return settings;
+
+            settings = AssetDatabase.LoadAssetAtPath<EditorGitToolSettings>(SettingsFilePath);
             if (settings == null)
             {
-                settings = ScriptableObject.CreateInstance<GitToolSettings>();
+                settings = ScriptableObject.CreateInstance<EditorGitToolSettings>();
                 settings.GitHashTextAssetPath = EditorGitTool.DefaultGitHashFilePath;
                 settings.ShowWarning = true;
                 AssetDatabase.CreateAsset(settings, SettingsFilePath);
@@ -50,7 +55,7 @@ namespace kamgam.editor.GitTool
                 label = "Git Tool",
                 guiHandler = (searchContext) =>
                 {
-                    var settings = GitToolSettings.GetSerializedSettings();
+                    var settings = EditorGitToolSettings.GetSerializedSettings();
                     settings.Update();
 
                     // Fix for default toggle not being clickable in some Unity versions (TODO: investigate).


### PR DESCRIPTION
Fix GitToolSettings，Show Warning Message No script asset for GitToolSettings. Check that the definition is in a file of the same name and that it compiles properly.

It seems that class name  and filename of the .cs have to have the same name for it to work.
https://forum.unity.com/threads/scriptable-object-allowing-creation-in-unity-but-doesnt-have-a-script.980253/

The file name will change from GitToolSettings to EditorGitToolSettings.

Before
![Snipaste_2024-01-30_12-39-04](https://github.com/kamgam/UnityEditorGitTool/assets/18550228/123b3473-de86-40d0-b7d6-ac499ec9d019)

After
![Snipaste_2024-01-30_12-32-44](https://github.com/kamgam/UnityEditorGitTool/assets/18550228/38694c6e-d415-4df0-90bf-0f388b24b007)
